### PR TITLE
feat: Allow unicode characters by setting charset

### DIFF
--- a/mkdocs_torillic/main.html
+++ b/mkdocs_torillic/main.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+  <meta charset="utf-8">
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
   <link href="{{ 'css/torillic.css'|url }}" rel="stylesheet">
   {%- for path in config.extra_css %}


### PR DESCRIPTION
Currently, unicode characters like "ü" are not being rendered correctly.

This works when setting the charset in main.html to utf-8.

It might break some obscure other encoding, but I'm not aware of any. And unicode is standard enough I think this should be fine. Also, it is nice to set the charset explicitly so the browser does not need to guess.

To test, just add an "ü" anywhere in the documentation and look at the webpage (in Firefox in my case).