### PR TITLE
feat: Add localization option to set TOC heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This theme, named after the fantasy setting of [Dungeons & Dragons](https://www.
 Torillic accepts the following theme configuration options in the `mkdocs.yaml` file:
 ### `background_image`
 Supply either a file path or a web link to an image to use for the site's background. If not supplied, will use the defaut Torillic background (wood planks).
+### `extra.toc_heading`
+Can be set to change the title of all content blocks. Default: `Contents`
 
 ## Page configuration
 Torillic accepts the following configuration options from an individual page's yaml frontmatter:

--- a/mkdocs_torillic/partials/global_contents.html
+++ b/mkdocs_torillic/partials/global_contents.html
@@ -10,7 +10,7 @@
 {% endfor %}
 
 {# add heading #}
-<h3>Contents</h3>
+<h3>{{config.extra.toc_heading or "Contents"}}</h3>
 
 {# add standalone pages first #}
 {% if nav_pages|length %}

--- a/mkdocs_torillic/partials/local_contents.html
+++ b/mkdocs_torillic/partials/local_contents.html
@@ -1,6 +1,6 @@
 
 {# add heading #}
-<h4>Contents</h4>
+<h4>{{config.extra.toc_heading or "Contents"}}</h4>
 {# add child pages #}
 <blockquote style="break-inside: avoid;">
 {% for item in page.parent.children %}


### PR DESCRIPTION
Allows to change the title of the Table of contents, which was previously hard-coded to `Contents`. Especially useful when writing in other languages than English.