### PR TITLE
fix: Always use page titles for contents/backlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ Torillic accepts the following theme configuration options in the `mkdocs.yaml` 
 Supply either a file path or a web link to an image to use for the site's background. If not supplied, will use the defaut Torillic background (wood planks).
 ### `extra.toc_heading`
 Can be set to change the title of all content blocks. Default: `Contents`
-### `extra.backlink`
-Can be set to change the name of all the links that take you one layer up. Default: The name of the page it links to or `Home` for first level pages.
-### `extra.home_name`
-Can be set to change the name of the home link on content pages. Overrides `extra.backlink` for these pages. Default: `Home`
 
 ## Page configuration
 Torillic accepts the following configuration options from an individual page's yaml frontmatter:
@@ -31,9 +27,6 @@ Whether to include a contents block and, if so, what kind. Options are:
 - `none`: Do not include a contents block
 
 If not supplied, the site homepage will have global contents block and section home pages will have a local contents block, other pages will not include a contents block.
-
-### `backlink`
-Can be set to change the name of the link that takes you one layer up. Stronger than any global setting.
 
 ## Tips & Tricks
 

--- a/mkdocs_torillic/partials/backlink.html
+++ b/mkdocs_torillic/partials/backlink.html
@@ -1,21 +1,28 @@
-{% if page == page.parent.children[0] %}
-    {# if page is a section homepage... #}
+{# use a namespace so that we can set stuff within a for loop #}
+{% set backlink = namespace(target=None) %}
+
+{% if page.is_index %}
     {% if page.parent.parent %}
         {# section homepages go to their grandparent #}
-        {% set backlink_title = page.meta.backlink or config.extra.backlink or page.parent.parent.title %}
+        {% set backlink.target = page.parent.parent %}
     {% else %}
-        {# ...apart from top level sections #}
-        {% set backlink_title = page.meta.backlink or config.extra.home_name or config.extra.backlink or "Home" %}
+        {# top-level section homepages go to the site home #}
+        {% set backlink.target = nav.homepage %}
     {% endif %}
 {% else %}
-    {# if page is just a page... #}
     {% if page.parent %}
-        {# pages go to their parent #}
-        {% set backlink_title = page.meta.backlink or config.extra.backlink or page.parent.title %}
+        {# regular pages go to their parent #}
+        {% set backlink.target = page.parent %}
     {% else %}
-        {# ...apart from top level pages #}
-        {% set backlink_title = page.meta.backlink or config.extra.home_name or config.extra.backlink or "Home" %}
+        {# top-level pages go to the site home #}
+        {% set backlink.target = nav.homepage %}
     {% endif %}
 {% endif %}
+{# if backlink has an index page, target that instead #}
+{% if backlink.target.is_section %}
+    {% for backlink_sibling in backlink.target.children if backlink_sibling.is_index %}
+        {% set backlink.target = backlink_sibling %}
+    {% endfor %}
+{% endif %}
 
-<a href=".." class="torillic-backlink">🡐 {{ backlink_title }}</a>
+<a href="{{ backlink.target.url | url }}" class="torillic-backlink">🡐 {{ backlink.target.title }}</a>

--- a/mkdocs_torillic/partials/global_contents.html
+++ b/mkdocs_torillic/partials/global_contents.html
@@ -30,9 +30,18 @@
 </h4>
 <blockquote style="break-inside: avoid;">
     {% for subitem in item.children %}
+        {# use a namespace so that we can set stuff within a sub-for loop #}
+        {% set index = namespace(obj=subitem) %}
+        {# if subitem is a section, navigate to its index page #}
+        {% if subitem.is_section %}
+            {% for child in subitem.children if child.is_index %}
+                {% set index.obj = child %}
+            {% endfor %}
+        {% endif %}
+        {# create list item #}
         {% if subitem != item.children[0] %}
     <li>
-        <a href="{% if subitem.is_section %}{{ subitem.children[0].url | url }}{% else %}{{ subitem.url | url }}{% endif %}">{{ subitem.title }}</a>
+        <a href="{{ index.obj.url | url }}">{{ index.obj.title }}</a>
     </li>
         {% endif %}
     {% endfor %}

--- a/mkdocs_torillic/partials/local_contents.html
+++ b/mkdocs_torillic/partials/local_contents.html
@@ -4,9 +4,18 @@
 {# add child pages #}
 <blockquote style="break-inside: avoid;">
 {% for item in page.parent.children %}
+    {# use a namespace so that we can set stuff within a sub-for loop #}
+    {% set index = namespace(obj=item) %}
+    {# if item is a section, navigate to its index page #}
+    {% if item.is_section %}
+        {% for child in item.children if child.is_index %}
+            {% set index.obj = child %}
+        {% endfor %}
+    {% endif %}
+    {# create list item #}
     {% if item != page.parent.children[0] %}
     <li>
-        <a href="{% if item.is_section %}{{ item.children[0].url | url }}{% else %}{{ item.url | url }}{% endif %}">{{ item.title }}</a>
+        <a href="{{ index.obj.url | url }}">{{ index.obj.title }}</a>
     </li>
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
Thanks to @502E532E for getting this ball rolling!

Previously, backlinks were always set to the title of the *object* they target, be that a Section or a Page. The problem is that a Section doesn't have an easily configurable title, and the parent of a top-level section doesn't have a title at all (so always defaulted to "Home").

@502E532E addressed this in #5 by adding configuration options to manually set this. However, this still means users have to edit their config to get the correct title on a page - which is doable but seems like more effort than it needs to be. If they already have a page title, why specify it again in frontmatter?

This PR makes it so that the backlink title (and a page/section's title in contents) is *always the title of the page it points to* - making it configurable as the title of each page is configurable, without having to specify anything manually in config. So the equivalent of `extra.home_name` is to change the title of the homepage, and the equivalent of `backlink` is to set the title of the next page up in the navigation. 

This feels more intuitive to me, but what do you think @502E532E? Does this still meet what you were going for with #5?