### PR TITLE
feat: add Torillic site search UI using MkDocs search plugin

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,23 +11,40 @@ jobs:
     steps:
     - name: Setup Python
       uses: actions/setup-python@v2
+
     - name: Checkout branch
       uses: actions/checkout@master
       with:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+    - name: Checkout base torillic
+      uses: actions/checkout@v3
+      with:
+        repository: TEParsons/torillic
+        ref: main
+        path: base
+
+    - name: Inject base Torillic
+      run: |
+        python base/utils/stub.py
+
     - name: Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install mkdocs mkdocs-torillic mkdocs-awesome-pages-plugin
+        pip install mkdocs mkdocs-awesome-pages-plugin
+        pip install .
+
     - name: Build
       run: |
         mkdocs build
+
     - name: Commit
       run: |
         git config --global user.email "todd.e.parsons@googlemail.com"
         git config --global user.name "Todd Parsons"
         git add --all
         git commit --all -m "Build"
+        
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ pip install mkdocs-torillic
 
 Alternatively, you can clone/download this repo and either store it in your Python path or use `pip install <path to your local folder>`. If you do so, just remember to use the `last-release` branch rather than `main` - the base theme is copied over from [here](https://github.com/TEParsons/torillic) when a release is built, so in the `main` (development) branch there's just a file called `torillic.stub` in its place.
 
+## Search
+Torillic can use MkDocs' built-in `search` plugin and render it in the theme header as a themed search bar with:
+- inline result display
+- partial-match suggestions
+- in-page highlighting when a suggestion is followed
+
+To enable it in your `mkdocs.yml`, include `search` in the plugin list:
+```yaml
+plugins:
+  - search
+```
+
+The example site in this repository also enables `search` in [`mkdocs.yml`](mkdocs.yml).
+
 ## Theme configuration
 Torillic accepts the following theme configuration options in the `mkdocs.yaml` file:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,8 @@ markdown_extensions:
   - md_in_html 
 # tell mkdocs what plugins to use
 plugins:
+  # built-in full-text search index and frontend assets
+  - search
   # awesome-pages works well Torillic's contents pages as it allows an automatic nav to be generated from file structure
   - awesome-pages
   # the torillic-statblock plugin enables the "statblock" language for code blocks

--- a/mkdocs_torillic/css/torillic.css
+++ b/mkdocs_torillic/css/torillic.css
@@ -9,6 +9,10 @@ body {
     margin: 0;
 }
 
+[hidden] {
+    display: none !important;
+}
+
 blockquote.torillic-toc {
     display: flex;
     flex-direction: column;
@@ -35,6 +39,177 @@ li.torillic-toc-page::marker {
     padding: 4rem;
 }
 
+.torillic-search-shell {
+    position: relative;
+    width: 21cm;
+    max-width: calc(100% - 4cm - 8rem);
+    margin: 1rem auto 0;
+}
+
+.torillic-search-form {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.torillic-search-label {
+    color: white;
+    font-family: var(--head);
+    font-size: 1rem;
+    font-variant: small-caps;
+    letter-spacing: 0.08em;
+    text-shadow: 1mm 1mm 2mm rgba(0, 0, 0, 0.45);
+}
+
+.torillic-search-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.torillic-search-input,
+.torillic-search-button {
+    border: 2px solid var(--yellow);
+    border-radius: 999px;
+    font-family: var(--body);
+    font-size: 1rem;
+}
+
+.torillic-search-input {
+    width: 100%;
+    padding: 0.8rem 1.1rem;
+    color: var(--red);
+    background:
+        linear-gradient(rgba(252, 245, 229, 0.98), rgba(252, 245, 229, 0.94)),
+        url("torillic/assets/paper-texture.png");
+    box-shadow: 0 0.35rem 1rem rgba(0, 0, 0, 0.25);
+}
+
+.torillic-search-input::placeholder {
+    color: rgba(130, 32, 0, 0.7);
+}
+
+.torillic-search-input:focus {
+    outline: 2px solid var(--green);
+    outline-offset: 2px;
+}
+
+.torillic-search-button {
+    padding: 0.8rem 1.4rem;
+    color: white;
+    background: linear-gradient(180deg, #9b350f 0%, var(--red) 100%);
+    cursor: pointer;
+    box-shadow: 0 0.35rem 1rem rgba(0, 0, 0, 0.25);
+}
+
+.torillic-search-button:hover {
+    border-color: var(--green);
+}
+
+.torillic-search-panel {
+    position: absolute;
+    top: calc(100% + 0.6rem);
+    left: 0;
+    right: 0;
+    z-index: 20;
+    padding: 1rem 1.25rem;
+    background-image: url("torillic/assets/paper-texture.png");
+    background-color: var(--offwhite);
+    border: 2px solid var(--yellow);
+    box-shadow:
+        inset 0 0 0.1cm 0.05cm rgba(0, 0, 0, 0.1),
+        0 0.75rem 1.5rem rgba(0, 0, 0, 0.35);
+}
+
+.torillic-search-suggest {
+    position: absolute;
+    top: calc(100% + 0.6rem);
+    left: 0;
+    right: 0;
+    z-index: 25;
+    display: grid;
+    gap: 0.35rem;
+    padding: 0.8rem;
+    background-image: url("torillic/assets/paper-texture.png");
+    background-color: var(--offwhite);
+    border: 2px solid var(--yellow);
+    box-shadow:
+        inset 0 0 0.1cm 0.05cm rgba(0, 0, 0, 0.1),
+        0 0.75rem 1.5rem rgba(0, 0, 0, 0.35);
+}
+
+.torillic-search-suggest-item {
+    display: grid;
+    gap: 0.15rem;
+    padding: 0.6rem 0.75rem;
+    text-decoration: none;
+    border-radius: 0.4rem;
+}
+
+.torillic-search-suggest-item:hover {
+    background: rgba(224, 229, 193, 0.75);
+}
+
+.torillic-search-suggest-item strong {
+    font-family: var(--head);
+    font-size: 1.1rem;
+}
+
+.torillic-search-suggest-item span {
+    color: inherit;
+    font-size: 0.95rem;
+}
+
+.torillic-search-results {
+    display: grid;
+    gap: 0.85rem;
+    max-height: min(55vh, 28rem);
+    overflow-y: auto;
+    color: var(--text-color);
+}
+
+.torillic-search-results article {
+    break-inside: avoid;
+    padding-bottom: 0.85rem;
+    border-bottom: 1px solid rgba(201, 173, 106, 0.7);
+}
+
+.torillic-search-results a,
+.torillic-search-results a:visited,
+.torillic-search-results p,
+.torillic-search-suggest,
+.torillic-search-suggest a,
+.torillic-search-suggest a:visited,
+.torillic-search-suggest span {
+    color: var(--text-color);
+}
+
+.torillic-search-results strong,
+.torillic-search-results h3,
+.torillic-search-suggest strong {
+    color: var(--red);
+}
+
+.torillic-search-results article:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+}
+
+.torillic-search-results h3 {
+    margin: 0 0 0.2rem;
+    font-size: 1.3rem;
+}
+
+.torillic-search-results p {
+    margin: 0;
+}
+
+mark {
+    padding: 0 0.12rem;
+    background: linear-gradient(180deg, rgba(224, 229, 193, 0.55), rgba(201, 173, 106, 0.75));
+    color: var(--red);
+}
+
 .torillic-backlink {
     position: absolute;
     top: 1cm;
@@ -47,6 +222,24 @@ li.torillic-toc-page::marker {
     opacity: 100%;
 }
 
+@media screen and (max-width: 836px) {
+    .torillic-background {
+        padding: 1rem;
+    }
+
+    .torillic-search-shell {
+        width: calc(100% - 1rem - 4cm);
+        max-width: none;
+    }
+
+    .torillic-search-row {
+        grid-template-columns: 1fr;
+    }
+
+    .torillic-search-suggest-item strong {
+        font-size: 1rem;
+    }
+}
 
 @media print {
     .torillic-backlink {

--- a/mkdocs_torillic/css/torillic/torillic.css
+++ b/mkdocs_torillic/css/torillic/torillic.css
@@ -82,6 +82,7 @@
   --yellow: #c9ad6a;
   --red: #822000;
   --purple: #704cd9;
+  --text-color: #2f2418;
 }
 
 

--- a/mkdocs_torillic/main.html
+++ b/mkdocs_torillic/main.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
   <link rel="icon" type="image/x-icon" href="{{ config.theme.favicon | url }}">
   <link href="{{ 'css/torillic.css'|url }}" rel="stylesheet">
@@ -40,6 +41,39 @@
       {% endif %}
       {% endfor %}
     </nav>
+    {% if 'search' in config.plugins %}
+    <div class="torillic-search-shell">
+      <form class="torillic-search-form" role="search" onsubmit="return false;">
+        <label class="torillic-search-label" for="mkdocs-search-query">Search the archive</label>
+        <div class="torillic-search-row">
+          <input
+            type="search"
+            id="mkdocs-search-query"
+            class="torillic-search-input"
+            placeholder="Search monsters, NPCs, places..."
+            title="Type search term here"
+            autocomplete="off"
+          >
+          <button
+            type="button"
+            class="torillic-search-button"
+            aria-label="Toggle search results"
+            onclick="toggleSearchResults()"
+          >
+            Search
+          </button>
+        </div>
+      </form>
+      <div id="torillic-search-suggest" class="torillic-search-suggest" hidden></div>
+      <div id="torillic-search-panel" class="torillic-search-panel" hidden aria-live="polite">
+        <div
+          id="mkdocs-search-results"
+          class="torillic-search-results"
+          data-no-results-text="No results found"
+        ></div>
+      </div>
+    </div>
+    {% endif %}
   </header>
   <main class="torillic-page">
     {# add page content #}
@@ -61,9 +95,277 @@
     {% endif %}
   </main>
   
+  {% if 'search' in config.plugins %}
+  <script>
+    var base_url = {{ base_url|tojson }};
+  </script>
+  {% endif %}
   {%- for script in config.extra_javascript %}
   {{ script | script_tag }}
   {%- endfor %}
+  {% if 'search' in config.plugins %}
+  <script>
+    var torillicSearchDocs = [];
+
+    function toggleSearchResults(forceOpen) {
+      var panel = document.getElementById("torillic-search-panel");
+      if (!panel) {
+        return;
+      }
+
+      var shouldOpen = forceOpen;
+      if (typeof shouldOpen !== "boolean") {
+        shouldOpen = panel.hidden;
+      }
+
+      panel.hidden = !shouldOpen;
+    }
+
+    function toggleSearchSuggest(forceOpen) {
+      var panel = document.getElementById("torillic-search-suggest");
+      if (!panel) {
+        return;
+      }
+
+      panel.hidden = !forceOpen;
+    }
+
+    function escapeHtml(value) {
+      return value.replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/\"/g, "&quot;");
+    }
+
+    function escapeRegExp(value) {
+      return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+
+    function joinTorillicUrl(base, path) {
+      if (!path) {
+        return base || ".";
+      }
+      if (path.substring(0, 1) === "/") {
+        return path;
+      }
+      if (!base || base === ".") {
+        return path;
+      }
+      if (base.substring(base.length - 1) === "/") {
+        return base + path;
+      }
+      return base + "/" + path;
+    }
+
+    function summarizeSuggestion(doc, query) {
+      var text = doc.text || "";
+      var normalized = text.toLowerCase();
+      var index = normalized.indexOf(query.toLowerCase());
+      if (index === -1) {
+        return text.slice(0, 120).trim();
+      }
+      var start = Math.max(0, index - 40);
+      var end = Math.min(text.length, index + query.length + 70);
+      return text.slice(start, end).trim();
+    }
+
+    function buildSuggestions(query) {
+      var normalized = query.trim().toLowerCase();
+      if (normalized.length < 2) {
+        return [];
+      }
+
+      var seen = new Set();
+      return torillicSearchDocs
+        .filter(function (doc) {
+          var title = (doc.title || "").toLowerCase();
+          var text = (doc.text || "").toLowerCase();
+          return title.indexOf(normalized) !== -1 || text.indexOf(normalized) !== -1;
+        })
+        .filter(function (doc) {
+          if (seen.has(doc.location)) {
+            return false;
+          }
+          seen.add(doc.location);
+          return true;
+        })
+        .sort(function (a, b) {
+          var aTitle = (a.title || "").toLowerCase();
+          var bTitle = (b.title || "").toLowerCase();
+          var aStarts = aTitle.indexOf(normalized) === 0 ? 0 : 1;
+          var bStarts = bTitle.indexOf(normalized) === 0 ? 0 : 1;
+          if (aStarts !== bStarts) {
+            return aStarts - bStarts;
+          }
+          return aTitle.localeCompare(bTitle);
+        })
+        .slice(0, 6);
+    }
+
+    function renderSuggestions(query) {
+      var suggest = document.getElementById("torillic-search-suggest");
+      if (!suggest) {
+        return;
+      }
+
+      var suggestions = buildSuggestions(query);
+      if (!suggestions.length) {
+        suggest.innerHTML = "";
+        toggleSearchSuggest(false);
+        return;
+      }
+
+      var pattern = new RegExp("(" + escapeRegExp(query.trim()) + ")", "ig");
+      var items = suggestions.map(function (doc, index) {
+        var title = escapeHtml(doc.title || "Untitled").replace(pattern, "<mark>$1</mark>");
+        var summary = escapeHtml(summarizeSuggestion(doc, query)).replace(pattern, "<mark>$1</mark>");
+        var href = joinTorillicUrl(base_url, doc.location) + "?q=" + encodeURIComponent(query.trim());
+        return [
+          '<a class="torillic-search-suggest-item" href="', href, '" data-suggest-index="', String(index), '">',
+          '<strong>', title, '</strong>',
+          '<span>', summary, '</span>',
+          "</a>"
+        ].join("");
+      });
+
+      suggest.innerHTML = items.join("");
+      toggleSearchSuggest(true);
+    }
+
+    function highlightSearchTerms() {
+      var query = new URLSearchParams(window.location.search).get("q");
+      if (!query) {
+        return;
+      }
+
+      var terms = query.trim().split(/\s+/).filter(function (term) {
+        return term.length >= 2;
+      });
+      if (!terms.length) {
+        return;
+      }
+
+      var root = document.querySelector(".torillic-page");
+      if (!root) {
+        return;
+      }
+
+      var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+        acceptNode: function (node) {
+          if (!node.nodeValue.trim()) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          if (node.parentElement && /^(SCRIPT|STYLE|MARK)$/.test(node.parentElement.tagName)) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          return NodeFilter.FILTER_ACCEPT;
+        }
+      });
+
+      var textNodes = [];
+      while (walker.nextNode()) {
+        textNodes.push(walker.currentNode);
+      }
+
+      var pattern = new RegExp("(" + terms.map(escapeRegExp).join("|") + ")", "ig");
+      textNodes.forEach(function (node) {
+        if (!pattern.test(node.nodeValue)) {
+          return;
+        }
+        pattern.lastIndex = 0;
+        var wrapper = document.createElement("span");
+        wrapper.innerHTML = escapeHtml(node.nodeValue).replace(pattern, "<mark>$1</mark>");
+        node.parentNode.replaceChild(wrapper, node);
+      });
+    }
+
+    function appendQueryToResultLinks(query) {
+      var searchResults = document.getElementById("mkdocs-search-results");
+      if (!searchResults || !query.trim()) {
+        return;
+      }
+
+      searchResults.querySelectorAll("a[href]").forEach(function (link) {
+        var targetUrl = new URL(link.getAttribute("href"), window.location.href);
+        targetUrl.searchParams.set("q", query.trim());
+        link.setAttribute("href", targetUrl.pathname + targetUrl.search + targetUrl.hash);
+      });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+      var searchShell = document.querySelector(".torillic-search-shell");
+      var searchInput = document.getElementById("mkdocs-search-query");
+      var searchResults = document.getElementById("mkdocs-search-results");
+      var searchSuggest = document.getElementById("torillic-search-suggest");
+
+      if (!searchShell || !searchInput || !searchResults) {
+        return;
+      }
+
+      fetch(joinTorillicUrl(base_url, "search/search_index.json"))
+        .then(function (response) { return response.json(); })
+        .then(function (data) {
+          torillicSearchDocs = data.docs || [];
+          var query = searchInput.value.trim();
+          if (query.length >= 2) {
+            renderSuggestions(query);
+          }
+        })
+        .catch(function () {
+          torillicSearchDocs = [];
+        });
+
+      searchInput.addEventListener("focus", function () {
+        toggleSearchResults(true);
+        if (searchInput.value.trim().length >= 2) {
+          renderSuggestions(searchInput.value);
+        }
+      });
+
+      searchInput.addEventListener("input", function () {
+        toggleSearchResults(true);
+        renderSuggestions(searchInput.value);
+      });
+
+      var searchObserver = new MutationObserver(function () {
+        appendQueryToResultLinks(searchInput.value);
+      });
+      searchObserver.observe(searchResults, { childList: true, subtree: true });
+
+      if (new URLSearchParams(window.location.search).get("q")) {
+        toggleSearchResults(true);
+      }
+
+      document.addEventListener("click", function (event) {
+        if (!searchShell.contains(event.target)) {
+          toggleSearchResults(false);
+          toggleSearchSuggest(false);
+        }
+      });
+
+      document.addEventListener("keydown", function (event) {
+        if (event.key === "Escape") {
+          toggleSearchResults(false);
+          toggleSearchSuggest(false);
+        }
+      });
+
+      searchResults.addEventListener("click", function (event) {
+        if (event.target.closest("a")) {
+          toggleSearchResults(false);
+        }
+      });
+
+      if (searchSuggest) {
+        searchSuggest.addEventListener("click", function () {
+          toggleSearchSuggest(false);
+        });
+      }
+
+      highlightSearchTerms();
+    });
+  </script>
+  {% endif %}
 </body>
 
 </html>


### PR DESCRIPTION
- Add MkDocs search plugin integration
- Add Torillic-themed search bar and result tray
- Add partial-match suggestions
- Add query-term highlighting on destination pages
- Defines the missing --text-color theme variable
- Documents search setup in the README
- Excludes generated docs/ output and uv.lock

Implementation support for this PR was done with OpenAI Codex (gpt-5.4 medium fast), with manual review and testing by me.